### PR TITLE
Changes Made

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ If `config.json` is missing or invalid, the application will raise an error with
   - Preservation of file permissions and formatting.
 - **Project Root Selection**: Interactive selection of project root directory with history, Tab autocompletion, and support for `~` (home directory). Change via `/rootdir` command.
 - **Multi-line Input**: Compose messages across multiple lines; send with **Alt+Enter**.
+- **Message History Navigation**: Navigate through previously sent messages with **Alt+Up/Down** keys.
 - **Session Logging**: Automatic saving of chat sessions as timestamped text files (e.g., `llm_session_20260130_151145.txt`) in the project root or user data directory.
 - **Token Estimation**: Built-in token estimator for input and output messages to monitor usage.
 - **Colorized UI Elements**: Enhanced help menu and outputs with colorization for better readability.

--- a/chat.py
+++ b/chat.py
@@ -252,6 +252,8 @@ class LLMChat:
             if send_result == 'insert_files':
                 next_default = user_input
                 continue
+            else:
+                self.input_handler.add_to_history(user_input)
             
         logger.debug("Exiting main chat loop")
         self._save_and_exit()


### PR DESCRIPTION
Closes #18 

1. input_handler.py - Added history management:
- Added history, history_index, and current_draft instance variables
- Added add_to_history() method to store sent messages (limited to 100 entries)
- Added Alt+Up/Alt+Down key bindings for history navigation
- Updated prompt message to show "Alt+Up/Down for history"
2. chat.py - Integrate history with chat loop:
- Modified the main chat loop to add user messages to history after successful sending
- Messages are only added to history when actually sent (not when file insertion is chosen)
3. README.md - Updated documentation:
- Added "Message History Navigation" feature description
- Documented Alt+Up/Down shortcut for navigating previously sent messages