### PR TITLE
The change adds logic to clear file lists when switching to a differe…

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -207,6 +207,19 @@ class LLMChat:
         self.root_dir = str(root_path)
         self.free_chat_mode = False
         
+        # Clear file lists when switching to a different project root
+        # Only clear if actually changing to a different directory (not same directory via different path)
+        should_clear_files = True
+        if old_root is not None:
+            # Compare resolved paths to see if it's the same directory
+            old_resolved = Path(old_root).resolve()
+            if old_resolved == root_path:
+                should_clear_files = False
+        
+        if should_clear_files:
+            self.editable_files = []
+            self.readable_files = []
+        
         # Update history
         self._add_to_recent_roots(self.history_file, self.root_dir)
         

--- a/tests/test_rootdir_file_clear.py
+++ b/tests/test_rootdir_file_clear.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Test that file lists are cleared when switching root directories."""
+import sys
+import os
+import tempfile
+import shutil
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import config
+from chat import LLMChat
+
+def test_rootdir_file_clearing():
+    """Test that file lists are cleared when switching between different roots."""
+    # Create temp directories
+    temp_dir = tempfile.mkdtemp()
+    config_dir = os.path.join(temp_dir, "config")
+    os.makedirs(config_dir, exist_ok=True)
+    
+    # Create two project directories
+    project1 = os.path.join(temp_dir, "project1")
+    project2 = os.path.join(temp_dir, "project2")
+    os.makedirs(project1, exist_ok=True)
+    os.makedirs(project2, exist_ok=True)
+    
+    # Create some test files
+    with open(os.path.join(project1, "file1.txt"), "w") as f:
+        f.write("test")
+    with open(os.path.join(project2, "file2.txt"), "w") as f:
+        f.write("test")
+    
+    # Create a minimal config.json
+    config_data = {
+        "models": {
+            "test-model": {
+                "api_key": "TEST_KEY",
+                "api_base_url": "https://example.com/v1"
+            }
+        }
+    }
+    import json
+    config_path = os.path.join(config_dir, "config.json")
+    with open(config_path, 'w') as f:
+        json.dump(config_data, f)
+    
+    # Set environment variable for API key
+    os.environ['TEST_KEY'] = 'dummy'
+    
+    try:
+        # Create LLMChat with project1 as root
+        chat = LLMChat(root_dir=project1, config_path=config_path)
+        assert chat.root_dir == project1
+        assert chat.free_chat_mode == False
+        
+        # Add some files to context (simulate via menu)
+        chat.editable_files = [os.path.join(project1, "file1.txt")]
+        chat.readable_files = [os.path.join(project1, "file1.txt")]
+        
+        # Switch to project2 - files should be cleared
+        chat.set_root_dir(project2)
+        assert chat.root_dir == project2
+        assert chat.editable_files == []
+        assert chat.readable_files == []
+        
+        # Add files in project2
+        chat.editable_files = [os.path.join(project2, "file2.txt")]
+        
+        # Switch back to project1 - files should be cleared again
+        chat.set_root_dir(project1)
+        assert chat.root_dir == project1
+        assert chat.editable_files == []
+        assert chat.readable_files == []
+        
+        print("✓ File clearing when switching root directories test passed")
+        
+        # Test: switching to same directory (different path representation) should not clear files
+        # Add files again
+        chat.editable_files = [os.path.join(project1, "file1.txt")]
+        
+        # Create a symlink to project1
+        symlink_path = os.path.join(temp_dir, "symlink_to_project1")
+        os.symlink(project1, symlink_path)
+        
+        # Switch via symlink - should recognize it's the same directory and not clear files
+        chat.set_root_dir(symlink_path)
+        # After resolution, root_dir should be project1
+        assert os.path.realpath(chat.root_dir) == project1
+        # Files should still be there (same directory)
+        assert len(chat.editable_files) == 1
+        assert chat.editable_files[0] == os.path.join(project1, "file1.txt")
+        
+        print("✓ Same directory detection preserves files test passed")
+        
+    finally:
+        # Cleanup
+        if 'TEST_KEY' in os.environ:
+            del os.environ['TEST_KEY']
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+if __name__ == "__main__":
+    test_rootdir_file_clearing()

--- a/tests/test_user_scenario.py
+++ b/tests/test_user_scenario.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Test the exact user scenario: switching roots with files in context."""
+import sys
+import os
+import tempfile
+import shutil
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import config
+from chat import LLMChat
+
+def test_user_scenario():
+    """
+    Simulate user scenario:
+    1. Start in thin-wrap root with files added
+    2. Switch to footstat root
+    3. Verify files are cleared
+    """
+    temp_dir = tempfile.mkdtemp()
+    config_dir = os.path.join(temp_dir, "config")
+    os.makedirs(config_dir, exist_ok=True)
+    
+    # Create mock project directories
+    thin_wrap = os.path.join(temp_dir, "thin-wrap")
+    footstat = os.path.join(temp_dir, "footstat")
+    os.makedirs(thin_wrap, exist_ok=True)
+    os.makedirs(footstat, exist_ok=True)
+    
+    # Create some files in thin-wrap
+    with open(os.path.join(thin_wrap, "chat.py"), "w") as f:
+        f.write("print('hello')")
+    with open(os.path.join(thin_wrap, "command_handler.py"), "w") as f:
+        f.write("print('world')")
+    with open(os.path.join(thin_wrap, "config.json"), "w") as f:
+        f.write('{"test": true}')
+    
+    # Create minimal config
+    config_data = {
+        "models": {
+            "test-model": {
+                "api_key": "TEST_KEY",
+                "api_base_url": "https://example.com/v1"
+            }
+        }
+    }
+    import json
+    config_path = os.path.join(config_dir, "config.json")
+    with open(config_path, 'w') as f:
+        json.dump(config_data, f)
+    
+    os.environ['TEST_KEY'] = 'dummy'
+    
+    try:
+        # Start in thin-wrap root (simulate via command line)
+        chat = LLMChat(root_dir=thin_wrap, config_path=config_path)
+        assert chat.root_dir == thin_wrap
+        
+        # Simulate user adding files via Ctrl+B menu
+        # (In real usage, these would be added via FileMenuApp)
+        chat.editable_files = [
+            os.path.join(thin_wrap, "chat.py"),
+            os.path.join(thin_wrap, "command_handler.py")
+        ]
+        chat.readable_files = [
+            os.path.join(thin_wrap, "config.json")
+        ]
+        
+        # Verify files are in context
+        assert len(chat.editable_files) == 2
+        assert len(chat.readable_files) == 1
+        
+        # Simulate /rootdir command to switch to footstat
+        chat.set_root_dir(footstat)
+        assert chat.root_dir == footstat
+        
+        # Files should be cleared
+        assert chat.editable_files == []
+        assert chat.readable_files == []
+        
+        # Verify _print_files_summary doesn't crash
+        # (should return early due to empty lists)
+        chat._print_files_summary()
+        
+        print("✓ User scenario test passed: files cleared when switching roots")
+        
+        # Additional test: switch back to thin-wrap, files should still be cleared
+        chat.set_root_dir(thin_wrap)
+        assert chat.editable_files == []
+        assert chat.readable_files == []
+        
+        print("✓ Switching back also clears files (fresh start)")
+        
+    finally:
+        if 'TEST_KEY' in os.environ:
+            del os.environ['TEST_KEY']
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+if __name__ == "__main__":
+    test_user_scenario()


### PR DESCRIPTION
…nt project root directory. It prevents clearing when the new root is actually the same directory (resolved via different paths), and only clears `editable_files` and `readable_files` when switching to a genuinely different directory.