### PR TITLE
docs: add YouTube play button overlay to Live Demo thumbnail

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A terminal chat for any LLM API endpoint -- bridging pure coding and vibe-coding.
 
 ## Live Demo
-At Hong-Kong Open-Source Conference 2026 ("[HKOSCon 2026](https://hkoscon.org/2026/topic/thin-wrap-my-python-version-of-opencode/)")
-[![Thin-Wrap Demo: Python CLI Connecting to Any LLM API](https://img.youtube.com/vi/j3pqtV_p4xQ/0.jpg)](https://youtu.be/j3pqtV_p4xQ)
+At Hong-Kong Open-Source Conference 2026 ("[HKOSCon 2026](https://hkoscon.org/2026/topic/thin-wrap-my-python-version-of-opencode/)")  
+[![Thin-Wrap Demo: Python CLI Connecting to Any LLM API](https://markdown-videos-api.jorgenkh.no/youtube/j3pqtV_p4xQ)](https://youtu.be/j3pqtV_p4xQ)
 ## Installation
 
 **Linux/macOS** (curl/wget + unzip required):


### PR DESCRIPTION
Use markdown-videos-api to display the red play arrow on the HKOSCon 2026 demo video thumbnail