### PR TITLE
feat(ui): make markdown link URLs visible and clickable

### DIFF
--- a/tests/test_markdown_links.py
+++ b/tests/test_markdown_links.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Tests for visible-URL handling of markdown links in UI rendering."""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from ui import make_links_visible, UI
+
+
+def test_labeled_link_gets_visible_url():
+    """[label](url) must render with the URL visible right after the label."""
+    result = make_links_visible("[AP News](https://apnews.com/hub/donald-trump)")
+    assert result == (
+        "[AP News](https://apnews.com/hub/donald-trump) "
+        "(https://apnews.com/hub/donald-trump)"
+    )
+
+
+def test_link_with_long_url_query():
+    """URLs with query strings must be handled."""
+    url = "https://apnews.com/live/trump-iran-news-updates-07-30-2026"
+    result = make_links_visible(f"[AP News: Trump says]({url})")
+    assert result == f"[AP News: Trump says]({url}) ({url})"
+
+
+def test_multiple_links_on_one_line():
+    """Every inline link on the same line must be transformed."""
+    result = make_links_visible(
+        "[Reuters](https://www.reuters.com/) and "
+        "[AP News](https://apnews.com/hub/donald-trump)"
+    )
+    assert result == (
+        "[Reuters](https://www.reuters.com/) (https://www.reuters.com/) and "
+        "[AP News](https://apnews.com/hub/donald-trump) "
+        "(https://apnews.com/hub/donald-trump)"
+    )
+
+
+def test_image_not_transformed():
+    """Image syntax ![alt](src) must be left untouched."""
+    src = "![alt text](https://example.com/img.png)"
+    assert make_links_visible(src) == src
+
+
+def test_bare_url_untouched():
+    """Plain URLs must be left untouched (already visible as text)."""
+    text = "Check https://apnews.com/hub/donald-trump for more."
+    assert make_links_visible(text) == text
+
+
+def test_autolink_untouched():
+    """Autolink syntax <https://...> must be left untouched."""
+    text = "See <https://example.com/page> now."
+    assert make_links_visible(text) == text
+
+
+def test_text_without_links_unchanged():
+    """Text with no inline links must be returned unchanged."""
+    text = "Hello **bold** world with a /command and 42."
+    assert make_links_visible(text) == text
+
+
+def test_render_markdown_includes_visible_url(capsys):
+    """UI.render_markdown must output the URL as visible text."""
+    UI.render_markdown(
+        "[AP News](https://apnews.com/hub/donald-trump)"
+    )
+    out = capsys.readouterr().out
+    assert "https://apnews.com/hub/donald-trump" in out

--- a/ui.py
+++ b/ui.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 from pathlib import Path
 from prompt_toolkit import PromptSession
 from prompt_toolkit.completion import PathCompleter
@@ -10,6 +11,21 @@ from rich.console import Console
 from strings import t
 
 logger = logging.getLogger(__name__)
+
+# Matches inline markdown links "[label](url)" while excluding images "![alt](src)"
+MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[([^\]]+)\]\((https?://[^)\s]+)\)")
+
+
+def make_links_visible(text: str) -> str:
+    """Make link targets visible as plain text for terminals without OSC 8 support.
+
+    Transforms "[label](url)" into "[label](url) (url)" so the URL can be
+    auto-detected and Ctrl+Clicked (or copied) in any terminal, including those
+    that fail to honor OSC 8 hyperlinks (e.g. Konsole).
+    """
+    return MARKDOWN_LINK_RE.sub(
+        lambda m: f"[{m.group(1)}]({m.group(2)}) ({m.group(2)})", text
+    )
 
 
 class UI:
@@ -79,12 +95,12 @@ class UI:
             return
         try:
             console = Console()
-            md = Markdown(text)
+            md = Markdown(make_links_visible(text))
             console.print(md)
         except Exception as e:
             # Log error with traceback and fallback to plain print if markdown rendering fails
             logger.exception("Failed to render markdown")
-            print(text)
+            print(make_links_visible(text))
 
     @staticmethod
     def interactive_selection(


### PR DESCRIPTION
Render markdown links as "[label](url)" plus the target URL as visible text, so links can be Ctrl+Clicked and copied in any terminal. Terminals without reliable OSC 8 hyperlink support (e.g. Konsole) now auto-detect the plain URL, while richer terminals keep the styled OSC 8 label link.