### PR TITLE
refactor(path): centralize path resolution in path_utils

### DIFF
--- a/command_handler.py
+++ b/command_handler.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 from ui import UI
 import config
+from path_utils import resolve_path
 from proxy_wrapper import validate_proxy_url
 from strings import t
 
@@ -15,8 +16,12 @@ class CommandHandler:
         self.input_handler = input_handler
         self.chat_app = chat_app
 
-    def handle_command(self, command):
-        """Handle user commands starting with '/'"""
+    def handle_command(self, command: str) -> bool:
+        """Handle user commands starting with '/'.
+
+        Returns:
+            True if the application should quit (e.g. /bye), False otherwise.
+        """
         command = command.strip()
         parts = command.split()
         cmd = parts[0].lower()
@@ -271,7 +276,7 @@ class CommandHandler:
         """Show or set project root directory using interactive selection with free chat option"""
         if args:
             # Direct path argument provided
-            new_root = Path(args[0]).expanduser().resolve()
+            new_root = resolve_path(args[0])
             if new_root.is_dir():
                 try:
                     self.chat_app.set_root_dir(str(new_root))
@@ -328,9 +333,8 @@ class CommandHandler:
 
                 # Manual path entry
                 try:
-                    new_item = Path(user_input).expanduser().resolve(strict=False)
-                    if new_item.is_dir():
-                        resolved_str = str(new_item)
+                    resolved_str = resolve_path(user_input)
+                    if Path(resolved_str).is_dir():
                         print(f"{t('common.using_prefix')} {resolved_str}")
                         self.chat_app.set_root_dir(resolved_str)
                         return

--- a/file_processor.py
+++ b/file_processor.py
@@ -9,6 +9,7 @@ import difflib
 from typing import Optional
 from tags import Xml
 from pathlib import Path
+from path_utils import resolve_path
 from strings import t
 
 logger = logging.getLogger(__name__)
@@ -25,13 +26,7 @@ def _resolve_file_path(path: str, root_dir: str) -> str:
     Returns:
         Absolute file path
     """
-    path_obj = Path(path)
-    if path_obj.is_absolute():
-        return str(path_obj)
-    else:
-        # Resolve relative to root directory
-        resolved = (Path(root_dir) / path).resolve()
-        return str(resolved)
+    return resolve_path(path, root_dir)
 
 
 def _read_file_content(full_path: str, root_dir: str) -> str:
@@ -304,7 +299,12 @@ def _diff_report(old_path: str | None, new_path: str) -> None:
             print(t("files.deletions", filename=filename, count=deletions))
         else:
             print(
-                t("files.insertions_deletions", filename=filename, insertions=insertions, deletions=deletions)
+                t(
+                    "files.insertions_deletions",
+                    filename=filename,
+                    insertions=insertions,
+                    deletions=deletions,
+                )
             )
 
     except Exception as e:
@@ -411,7 +411,12 @@ def parse_xml_response(llm_response: str) -> str:
                     print(t("files.deletions", filename=path.name, count=deletions))
                 else:
                     print(
-                        t("files.insertions_deletions", filename=path.name, insertions=insertions, deletions=deletions)
+                        t(
+                            "files.insertions_deletions",
+                            filename=path.name,
+                            insertions=insertions,
+                            deletions=deletions,
+                        )
                     )
 
                 logger.info(

--- a/menu.py
+++ b/menu.py
@@ -3,6 +3,7 @@ from textual.app import App, ComposeResult
 from textual.widgets import Header, Footer, DirectoryTree, ListView, ListItem, Static
 from textual.containers import Horizontal, Vertical
 from textual.binding import Binding
+from path_utils import resolve_path
 from strings import t
 
 
@@ -11,12 +12,20 @@ class FileMenuApp(App):
 
     ENABLE_COMMAND_PALETTE = False
     BINDINGS = [
-        Binding("ctrl+b", "quit", t("menus.shortcuts.quit"), key_display="Ctrl+B", show=True),
+        Binding(
+            "ctrl+b", "quit", t("menus.shortcuts.quit"), key_display="Ctrl+B", show=True
+        ),
         Binding("escape", "quit", t("menus.shortcuts.quit")),
         Binding("r", "to_readable", t("menus.shortcuts.readable")),
         Binding("e", "to_editable", t("menus.shortcuts.editable")),
         Binding("d", "delete_selected", t("menus.shortcuts.delete")),
-        Binding("ctrl+d", "clear_lists", t("menus.shortcuts.clear_all"), key_display="Ctrl+D", show=True),
+        Binding(
+            "ctrl+d",
+            "clear_lists",
+            t("menus.shortcuts.clear_all"),
+            key_display="Ctrl+D",
+            show=True,
+        ),
     ]
     CSS = """
     Horizontal { height: 100%; }
@@ -33,7 +42,7 @@ class FileMenuApp(App):
         super().__init__()
         self.editable_files = editable_files
         self.readable_files = readable_files
-        self.root_dir = os.path.abspath(root_dir)
+        self.root_dir = resolve_path(root_dir)
         self.editable_set = set(editable_files)
         self.readable_set = set(readable_files)
 

--- a/path_utils.py
+++ b/path_utils.py
@@ -1,0 +1,26 @@
+"""Centralized file path resolution utilities."""
+
+import os
+from pathlib import Path
+
+
+def resolve_path(path: str, root_dir: str | None = None) -> str:
+    """
+    Resolve a path to an absolute, normalized path.
+
+    Args:
+        path: Input path (absolute or relative)
+        root_dir: Root directory for resolving relative paths
+
+    Returns:
+        Resolved absolute path string
+    """
+    path_obj = Path(path).expanduser()
+
+    if not path_obj.is_absolute() and root_dir:
+        path_obj = Path(root_dir) / path_obj
+
+    try:
+        return str(path_obj.resolve())
+    except (OSError, RuntimeError, ValueError):
+        return os.path.abspath(str(path_obj))

--- a/thin_wrap.py
+++ b/thin_wrap.py
@@ -24,6 +24,7 @@ from command_handler import CommandHandler
 from file_processor import generate_query, generate_plain_query, parse_plain_response
 from input_handler import InputHandler
 from llm_client import LLMClient
+from path_utils import resolve_path
 from proxy_wrapper import create_proxy_wrapper, validate_proxy_url, normalize_proxy_url
 from session_logger import SessionLogger
 from strings import t
@@ -104,12 +105,12 @@ class LLMChat:
 
         # Process root directory
         if root_dir is not None:
-            root_path = Path(root_dir).expanduser().resolve()
-            if not root_path.is_dir():
+            root_path = resolve_path(root_dir)
+            if not Path(root_path).is_dir():
                 raise ValueError(
                     f"Specified root_dir is not a valid directory: {root_path}"
                 )
-            self.root_dir = str(root_path)
+            self.root_dir = root_path
             self.free_chat_mode = False
             self._add_to_recent_roots(history_file, self.root_dir)
             print(
@@ -134,23 +135,12 @@ class LLMChat:
             assert (
                 self.root_dir is not None
             ), "root_dir must be set when free_chat_mode is False"
-            root_path = Path(self.root_dir)
-            self.editable_files = [
-                str(
-                    (
-                        Path(p).resolve() if Path(p).is_absolute() else (root_path / p)
-                    ).resolve()
-                )
-                for p in (editable_files or [])
-            ]
-            self.readable_files = [
-                str(
-                    (
-                        Path(p).resolve() if Path(p).is_absolute() else (root_path / p)
-                    ).resolve()
-                )
-                for p in (readable_files or [])
-            ]
+            self.editable_files = self._resolve_file_list(
+                editable_files or [], self.root_dir
+            )
+            self.readable_files = self._resolve_file_list(
+                readable_files or [], self.root_dir
+            )
         self.first_message = "" if not first_message else first_message
         self.proxy_wrapper = create_proxy_wrapper(proxy_url) if proxy_url else None
 
@@ -166,6 +156,16 @@ class LLMChat:
             self.llm_client, self.session_logger, self.input_handler, self
         )
         logger.debug("Initialized all LLMChat components")
+
+    def _resolve_file_list(self, files: list[str], root_dir: str) -> list[str]:
+        """Resolve a list of file paths, skipping any that fail to resolve."""
+        resolved = []
+        for f in files:
+            try:
+                resolved.append(resolve_path(f, root_dir))
+            except Exception as e:
+                logger.warning(f"Skipping unresolvable file {f}: {e}")
+        return resolved
 
     def _load_recent_roots(self, history_file: Path) -> list[str]:
         """Load recent root_dirs from history file."""
@@ -294,9 +294,8 @@ class LLMChat:
                     continue
             # Manual path entry
             try:
-                new_item = Path(user_input).expanduser().resolve(strict=False)
-                if new_item.is_dir():
-                    resolved_str = str(new_item)
+                resolved_str = resolve_path(user_input)
+                if Path(resolved_str).is_dir():
                     print(f"{t('common.using_prefix')} {resolved_str}")
                     return resolved_str
                 else:
@@ -331,14 +330,14 @@ class LLMChat:
             return
 
         # Otherwise, it's a directory path
-        root_path = Path(new_root).expanduser().resolve()
-        if not root_path.is_dir():
+        root_path = resolve_path(new_root)
+        if not Path(root_path).is_dir():
             raise ValueError(
                 f"Specified root_dir is not a valid directory: {root_path}"
             )
 
         old_root = self.root_dir
-        self.root_dir = str(root_path)
+        self.root_dir = root_path
         self.free_chat_mode = False
 
         # Clear file lists when switching to a different project root
@@ -346,7 +345,7 @@ class LLMChat:
         should_clear_files = True
         if old_root is not None:
             # Compare resolved paths to see if it's the same directory
-            old_resolved = Path(old_root).resolve()
+            old_resolved = resolve_path(old_root)
             if old_resolved == root_path:
                 should_clear_files = False
 


### PR DESCRIPTION
- Add resolve_path() helper (expanduser + resolve relative to root, fallback on resolution errors)
- Replace duplicated path resolution in thin_wrap.py, command_handler.py, menu.py and file_processor.py
- Make file list resolution per-file tolerant: unresolvable files are skipped with a warning instead of failing init
- Document handle_command() True=quit return semantics and add type hint


closes #29 